### PR TITLE
replace both compile.txt with Makefiles

### DIFF
--- a/src/jessesort/Makefile
+++ b/src/jessesort/Makefile
@@ -1,0 +1,5 @@
+CC=g++
+CFLAGS=-O3 -std=c++14
+
+jesseSortTest: jesseSort.cpp main.cpp
+	$(CC) $(CFLAGS) main.cpp jesseSort.cpp -o jesseSortTest

--- a/src/jessesort/compile.txt
+++ b/src/jessesort/compile.txt
@@ -1,1 +1,0 @@
-g++ -O3 main.cpp jesseSort.cpp -o jesseSortTest

--- a/src/patiencesort/Makefile
+++ b/src/patiencesort/Makefile
@@ -1,0 +1,5 @@
+CC=g++
+CFLAGS=-O3 -std=c++14
+
+patienceSortTest: patienceSort.cpp patienceSort.hpp main.cpp
+	$(CC) $(CFLAGS) main.cpp patienceSort.cpp -o patienceSortTest

--- a/src/patiencesort/compile.txt
+++ b/src/patiencesort/compile.txt
@@ -1,1 +1,0 @@
-g++ -O3 main.cpp patienceSort.cpp -o patienceSortTest


### PR DESCRIPTION
Replace both compile.txt with Makefiles but keeping them inside their respective directories. The workflow for compiling is now:

1. `cd` into the correct source directory (`src/jessesort` or `src/patiencesort`)
2. build the test binary by calling `make`.
 
This eliminates the need for copy-pasting the compile command from `compile.txt`. The Makefiles also specify the minimum required C++ standard (14).